### PR TITLE
Use newest compatible HexTree crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,8 +503,7 @@ dependencies = [
 [[package]]
 name = "hextree"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b441cd933ac3eadde9f01898ef12bb3d4560fbe1aeaf3eb2e5bff5bdd7715a17"
+source = "git+https://github.com/JayKickliter/HexTree.git?rev=ca7d1dac68fc01a1b0bfe48f6481cb23d9d23b28#ca7d1dac68fc01a1b0bfe48f6481cb23d9d23b28"
 dependencies = [
  "h3ron",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bincode = "1.3.3"
 bytes = "1.3.0"
 clap = {version = "3.2.20", features = ["derive"]}
 geo = "0.23.0"
-hextree = {version = "0.1", features = ["serde-support"]}
+hextree = {git = "https://github.com/JayKickliter/HexTree.git", rev = "ca7d1dac68fc01a1b0bfe48f6481cb23d9d23b28", features = ["serde-support"]}
 http-body-util = "0.1.0-rc.2"
 hyper = {version = "0.14.23", features = ["server", "http1", "full"]}
 num-traits = "0.2.15"


### PR DESCRIPTION
This fixes the broken `main` branch which can't deserialize the current huge hexmap. It does so by updating the hextree crate dep to the newest commit which is compatible with the current serialized gpw.hexmap.