### PR TITLE
Fix indexing error

### DIFF
--- a/gpwgen/src/generate.rs
+++ b/gpwgen/src/generate.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use std::io::Write;
 
 pub fn tessalate_grid(header: &GpwAsciiHeader, row: usize, col: usize) -> Vec<u64> {
-    let grid_bottom_degs = header.yllcorner + header.cellsize * (header.nrows - row + 1) as f64;
+    let grid_bottom_degs = header.yllcorner + header.cellsize * (header.nrows - row - 1) as f64;
     let grid_top_degs = grid_bottom_degs + header.cellsize;
     let grid_left_degs = header.xllcorner + header.cellsize * col as f64;
     let grid_right_degs = grid_left_degs + header.cellsize;


### PR DESCRIPTION
The current logic to account for indexing the rows in asc files is inverted, resulting in a Y-axis error of about 1.8 km.