### PR TITLE
Use jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +357,7 @@ dependencies = [
  "geo",
  "hextree 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -364,6 +371,7 @@ dependencies = [
  "hextree 0.1.0 (git+https://github.com/JayKickliter/HexTree.git?rev=38d4b1384baccc02de946e084f76ccfb591792e9)",
  "hyper",
  "indicatif",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -973,6 +981,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.2+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/gpwgen/Cargo.toml
+++ b/gpwgen/Cargo.toml
@@ -18,3 +18,6 @@ clap = {version = "*", features = ["derive"]}
 geo = "*"
 hextree = "*"
 rayon = "*"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"

--- a/gpwgen/src/main.rs
+++ b/gpwgen/src/main.rs
@@ -16,6 +16,13 @@ use std::{
     io::{BufReader, BufWriter, ErrorKind},
     path::PathBuf,
 };
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 
 fn main() -> Result<()> {
     let args = Args::parse();

--- a/gpws/Cargo.toml
+++ b/gpws/Cargo.toml
@@ -12,3 +12,6 @@ hextree = {git = "https://github.com/JayKickliter/HexTree.git", rev = "38d4b1384
 hyper = {version = "*", features = ["server", "http1", "full"]}
 indicatif = "*"
 tokio = {version = "*", features = ["full"]}
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"

--- a/gpws/src/main.rs
+++ b/gpws/src/main.rs
@@ -22,6 +22,12 @@ use std::{
     thread,
     time::Duration,
 };
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
On macOS at least, generation is several orders of magnitude faster with jemalloc compared to using libc's allocator. Loading the hexmap with gpws is also sever times faster.